### PR TITLE
[iOS] Feat: 제품 상세 페이지 이미지 캐싱 기능 추가

### DIFF
--- a/iOS/SecondHand/SecondHand.xcodeproj/project.pbxproj
+++ b/iOS/SecondHand/SecondHand.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		63608CC82A40D273006CD876 /* DetailToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63608CC72A40D273006CD876 /* DetailToolbar.swift */; };
 		63608CCA2A40DA46006CD876 /* UIFont+Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63608CC92A40DA45006CD876 /* UIFont+Typography.swift */; };
 		6362335F2A65094500664C07 /* DetailModelMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6362335E2A65094500664C07 /* DetailModelMapper.swift */; };
+		639B2BAA2A6CF15900D0C1DF /* ProductImageViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 639B2BA92A6CF15900D0C1DF /* ProductImageViewer.swift */; };
 		63A3FCDE2A3740C800361FAD /* SellerInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A3FCDD2A3740C800361FAD /* SellerInfoView.swift */; };
 		63A3FCE32A3968AC00361FAD /* DetailContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A3FCE22A3968AC00361FAD /* DetailContentView.swift */; };
 		63A3FCE92A3983C500361FAD /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A3FCE82A3983C500361FAD /* DetailViewController.swift */; };
@@ -165,6 +166,7 @@
 		63608CC72A40D273006CD876 /* DetailToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailToolbar.swift; sourceTree = "<group>"; };
 		63608CC92A40DA45006CD876 /* UIFont+Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Typography.swift"; sourceTree = "<group>"; };
 		6362335E2A65094500664C07 /* DetailModelMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailModelMapper.swift; sourceTree = "<group>"; };
+		639B2BA92A6CF15900D0C1DF /* ProductImageViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImageViewer.swift; sourceTree = "<group>"; };
 		63A3FCC42A3709AA00361FAD /* Pods.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = Pods.xcodeproj; sourceTree = "<group>"; };
 		63A3FCDD2A3740C800361FAD /* SellerInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SellerInfoView.swift; sourceTree = "<group>"; };
 		63A3FCE22A3968AC00361FAD /* DetailContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailContentView.swift; sourceTree = "<group>"; };
@@ -361,6 +363,7 @@
 			isa = PBXGroup;
 			children = (
 				63A3FCE22A3968AC00361FAD /* DetailContentView.swift */,
+				639B2BA92A6CF15900D0C1DF /* ProductImageViewer.swift */,
 				63A3FCDD2A3740C800361FAD /* SellerInfoView.swift */,
 				63608CBE2A4061E0006CD876 /* ProductInfoView.swift */,
 				63608CC52A407FB8006CD876 /* CommunicationInfoView.swift */,
@@ -857,6 +860,7 @@
 				6320476C2A440B290035880A /* LoginButtonGroupView.swift in Sources */,
 				FFD62C242A3C1BBF0014D2D4 /* LocationLabel.swift in Sources */,
 				FF61AD2E2A36FB68006AE167 /* ItemListTableViewCell.swift in Sources */,
+				639B2BAA2A6CF15900D0C1DF /* ProductImageViewer.swift in Sources */,
 				63E94CE62A4C98FB00B0376D /* DecodeManager.swift in Sources */,
 				FF61AD292A36F294006AE167 /* ItemListViewController.swift in Sources */,
 				FFD62C2F2A3C1E260014D2D4 /* Typography.swift in Sources */,

--- a/iOS/SecondHand/SecondHand.xcodeproj/project.pbxproj
+++ b/iOS/SecondHand/SecondHand.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		20CDE5D6BAC315408A7274A6 /* Pods_SecondHand.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AD8568FDDCC422CE5C5678E /* Pods_SecondHand.framework */; };
 		6308CAA92A518E6300E38437 /* IdValidationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6308CAA82A518E6300E38437 /* IdValidationDelegate.swift */; };
 		63129C9A2A4145B00049EC0C /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63129C992A4145B00049EC0C /* LoginViewController.swift */; };
+		6313CAE02A6AD5BD00704845 /* PassedTimeGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6313CADF2A6AD5BD00704845 /* PassedTimeGenerator.swift */; };
 		632047602A42F28F0035880A /* AccountInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6320475F2A42F28F0035880A /* AccountInputView.swift */; };
 		6320476C2A440B290035880A /* LoginButtonGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6320476B2A440B290035880A /* LoginButtonGroupView.swift */; };
 		632047732A4411AC0035880A /* AccountButtonUIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632047722A4411AC0035880A /* AccountButtonUIFactory.swift */; };
@@ -130,6 +131,7 @@
 		5C080CDDECA0178F002D21F4 /* Pods-SecondHand-SecondHandTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SecondHand-SecondHandTests.release.xcconfig"; path = "Target Support Files/Pods-SecondHand-SecondHandTests/Pods-SecondHand-SecondHandTests.release.xcconfig"; sourceTree = "<group>"; };
 		6308CAA82A518E6300E38437 /* IdValidationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdValidationDelegate.swift; sourceTree = "<group>"; };
 		63129C992A4145B00049EC0C /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		6313CADF2A6AD5BD00704845 /* PassedTimeGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassedTimeGenerator.swift; sourceTree = "<group>"; };
 		6320475F2A42F28F0035880A /* AccountInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInputView.swift; sourceTree = "<group>"; };
 		6320476B2A440B290035880A /* LoginButtonGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginButtonGroupView.swift; sourceTree = "<group>"; };
 		632047722A4411AC0035880A /* AccountButtonUIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountButtonUIFactory.swift; sourceTree = "<group>"; };
@@ -300,6 +302,7 @@
 				633AC5C42A499FC700A34501 /* UIViewController+setTitle.swift */,
 				63E94CE32A4C949900B0376D /* SecretKeys.swift */,
 				63E6B8AF2A629E03009357B6 /* ImageCacheManager.swift */,
+				6313CADF2A6AD5BD00704845 /* PassedTimeGenerator.swift */,
 				63D98E892A4546C600DF467A /* Network */,
 				63D98E882A45462D00DF467A /* Factory */,
 				FFD62C2D2A3C1DFC0014D2D4 /* ShareComponent */,
@@ -884,6 +887,7 @@
 				FF61AD602A3BE4D9006AE167 /* ColorPalette.swift in Sources */,
 				63608CBF2A4061E0006CD876 /* ProductInfoView.swift in Sources */,
 				633AC5BD2A49224F00A34501 /* LoginView.swift in Sources */,
+				6313CAE02A6AD5BD00704845 /* PassedTimeGenerator.swift in Sources */,
 				63E6B89A2A61126A009357B6 /* PasswordValidationDelegate.swift in Sources */,
 				633AC5B12A480B3600A34501 /* LoginDTO.swift in Sources */,
 				63E94CE82A4C9A8700B0376D /* DTO.swift in Sources */,

--- a/iOS/SecondHand/SecondHand.xcodeproj/project.pbxproj
+++ b/iOS/SecondHand/SecondHand.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		6308CAA92A518E6300E38437 /* IdValidationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6308CAA82A518E6300E38437 /* IdValidationDelegate.swift */; };
 		63129C9A2A4145B00049EC0C /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63129C992A4145B00049EC0C /* LoginViewController.swift */; };
 		6313CAE02A6AD5BD00704845 /* PassedTimeGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6313CADF2A6AD5BD00704845 /* PassedTimeGenerator.swift */; };
+		6313CAE72A6AE3FB00704845 /* FormatPriceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6313CAE62A6AE3FB00704845 /* FormatPriceGenerator.swift */; };
 		632047602A42F28F0035880A /* AccountInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6320475F2A42F28F0035880A /* AccountInputView.swift */; };
 		6320476C2A440B290035880A /* LoginButtonGroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6320476B2A440B290035880A /* LoginButtonGroupView.swift */; };
 		632047732A4411AC0035880A /* AccountButtonUIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 632047722A4411AC0035880A /* AccountButtonUIFactory.swift */; };
@@ -132,6 +133,7 @@
 		6308CAA82A518E6300E38437 /* IdValidationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdValidationDelegate.swift; sourceTree = "<group>"; };
 		63129C992A4145B00049EC0C /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		6313CADF2A6AD5BD00704845 /* PassedTimeGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassedTimeGenerator.swift; sourceTree = "<group>"; };
+		6313CAE62A6AE3FB00704845 /* FormatPriceGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatPriceGenerator.swift; sourceTree = "<group>"; };
 		6320475F2A42F28F0035880A /* AccountInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInputView.swift; sourceTree = "<group>"; };
 		6320476B2A440B290035880A /* LoginButtonGroupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginButtonGroupView.swift; sourceTree = "<group>"; };
 		632047722A4411AC0035880A /* AccountButtonUIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountButtonUIFactory.swift; sourceTree = "<group>"; };
@@ -303,6 +305,7 @@
 				63E94CE32A4C949900B0376D /* SecretKeys.swift */,
 				63E6B8AF2A629E03009357B6 /* ImageCacheManager.swift */,
 				6313CADF2A6AD5BD00704845 /* PassedTimeGenerator.swift */,
+				6313CAE62A6AE3FB00704845 /* FormatPriceGenerator.swift */,
 				63D98E892A4546C600DF467A /* Network */,
 				63D98E882A45462D00DF467A /* Factory */,
 				FFD62C2D2A3C1DFC0014D2D4 /* ShareComponent */,
@@ -873,6 +876,7 @@
 				632047732A4411AC0035880A /* AccountButtonUIFactory.swift in Sources */,
 				632CA6C32A4E6EC700C0E639 /* ItemDetailDTO.swift in Sources */,
 				FF54649B2A407512008519A9 /* Network.swift in Sources */,
+				6313CAE72A6AE3FB00704845 /* FormatPriceGenerator.swift in Sources */,
 				FF3942CD2A4C199A00B9722F /* SignUpNetworkManager+Error.swift in Sources */,
 				63A3FCE32A3968AC00361FAD /* DetailContentView.swift in Sources */,
 				63E94CE42A4C949900B0376D /* SecretKeys.swift in Sources */,

--- a/iOS/SecondHand/SecondHand/Detail/DetailRepository.swift
+++ b/iOS/SecondHand/SecondHand/Detail/DetailRepository.swift
@@ -47,7 +47,7 @@ struct DetailRepository {
         
         // 4. 디스크 캐시에 존재하는 이미지들은 가져와서 메모리 캐시에 저장.
         // 디스크 캐시에 존재하는 파일들만 추출
-        let nonDiskCachedImages = nonMemoryCachedImages.enumerated().filter { (imageNumber: Int, key: NSString) in
+        let nonDiskCachedImages = nonMemoryCachedImages.enumerated().filter { (imageNumber: Int, _) in
             return !self.localDataSource.checkFileExists(name: "\(index)/\(imageNumber)")
         }
         // 모두 디스크 캐시에 이미 존재한다면, 메모리 캐시에 저장 후 모델 리턴

--- a/iOS/SecondHand/SecondHand/Detail/DetailUseCase.swift
+++ b/iOS/SecondHand/SecondHand/Detail/DetailUseCase.swift
@@ -23,6 +23,7 @@ final class DetailUseCase {
             }
 
             self.detail = detailModel
+            print(detailModel.imageKeys)
             self.dataSender?(detailModel)
         }
     }

--- a/iOS/SecondHand/SecondHand/Detail/DetailViewController.swift
+++ b/iOS/SecondHand/SecondHand/Detail/DetailViewController.swift
@@ -23,7 +23,7 @@ class DetailViewController: UIViewController {
         super.viewDidLoad()
         self.view.backgroundColor = .white
         self.setTabBar(isHiding: true)
-        self.detailUseCase.fetchData(item: 98)
+        self.detailUseCase.fetchData(item: 101)
         self.setDataSender()
     }
 

--- a/iOS/SecondHand/SecondHand/Detail/DetailViewController.swift
+++ b/iOS/SecondHand/SecondHand/Detail/DetailViewController.swift
@@ -44,7 +44,7 @@ class DetailViewController: UIViewController {
     
     private func setDataSender() {
         self.detailUseCase.dataSender = { (data) in
-            self.toolbar.configure(price: data.price)
+            self.toolbar.update(price: data.price)
             self.detailContentView.update(by: data)
         }
     }

--- a/iOS/SecondHand/SecondHand/Detail/UI/CommunicationInfoView.swift
+++ b/iOS/SecondHand/SecondHand/Detail/UI/CommunicationInfoView.swift
@@ -14,17 +14,13 @@ class CommunicationInfoView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.addSubviews()
         self.setFont()
+        self.addSubviews()
+        self.addConstraints()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-    }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        self.addConstraints()
     }
     
     func update(by userInteractionCount: DetailModel.UserInteractionCount) {
@@ -71,21 +67,25 @@ extension CommunicationInfoView {
     private func addConstraintsToChatCountLabel() {
         NSLayoutConstraint.activate([
             self.chatCountLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.chatCountLabel.topAnchor.constraint(equalTo: self.topAnchor)
+            self.chatCountLabel.topAnchor.constraint(equalTo: self.topAnchor),
+            self.chatCountLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
     }
     
     private func addConstraintsToFavoriteCountLabel() {
         NSLayoutConstraint.activate([
             self.favoriteCountLabel.leadingAnchor.constraint(equalTo: self.chatCountLabel.trailingAnchor, constant: 8),
-            self.favoriteCountLabel.topAnchor.constraint(equalTo: chatCountLabel.topAnchor)
+            self.favoriteCountLabel.topAnchor.constraint(equalTo: chatCountLabel.topAnchor),
+            self.favoriteCountLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
     }
     
     private func addConstraintsToViewsCountLabel() {
         NSLayoutConstraint.activate([
             self.viewsCountLabel.leadingAnchor.constraint(equalTo: self.favoriteCountLabel.trailingAnchor, constant: 8),
-            self.viewsCountLabel.topAnchor.constraint(equalTo: chatCountLabel.topAnchor)
+            self.viewsCountLabel.topAnchor.constraint(equalTo: chatCountLabel.topAnchor),
+            self.viewsCountLabel.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor),
+            self.viewsCountLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
     }
 }

--- a/iOS/SecondHand/SecondHand/Detail/UI/DetailContentView.swift
+++ b/iOS/SecondHand/SecondHand/Detail/UI/DetailContentView.swift
@@ -17,9 +17,9 @@ class DetailContentView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        self.setUI()
         self.addSubviews()
         self.addConstraints()
-        self.setUI()
     }
     
     required init?(coder: NSCoder) {
@@ -36,7 +36,6 @@ class DetailContentView: UIView {
             self.productImageView.image = UIImage(contentsOfFile: productImageURLString)
             self.sellerInfoView.update(by: data.sellerName)
             self.productInfoView.update(by: data.productInfo)
-            self.communicationInfoView.update(by: data.userInteractionCount)
         }
     }
     
@@ -57,7 +56,7 @@ class DetailContentView: UIView {
         button.layer.borderColor = UIColor.gray.cgColor
         button.layer.borderWidth = 0.2
         button.layer.cornerRadius = 8
-        
+
         var configuration = UIButton.Configuration.plain()
         configuration.contentInsets = NSDirectionalEdgeInsets(
             top: 8,
@@ -66,7 +65,7 @@ class DetailContentView: UIView {
             trailing: 16
         )
         button.configuration = configuration
-        
+
         let onReservation = UIAction(
             title: "예약중",
             handler: { _ in
@@ -80,7 +79,7 @@ class DetailContentView: UIView {
                 return
             }
         )
-        
+
         button.menu = UIMenu(
             options: .displayInline,
             children: [onReservation, onSold])
@@ -163,9 +162,9 @@ extension DetailContentView {
     
     private func addConstraintsToProductInfo() {
         NSLayoutConstraint.activate([
-            self.productInfoView.leadingAnchor.constraint(equalTo: sellerInfoView.leadingAnchor),
-            self.productInfoView.trailingAnchor.constraint(lessThanOrEqualTo: sellerInfoView.trailingAnchor),
-            self.productInfoView.topAnchor.constraint(equalTo: statusButton.bottomAnchor, constant: 16),
+            self.productInfoView.leadingAnchor.constraint(equalTo: self.sellerInfoView.leadingAnchor),
+            self.productInfoView.trailingAnchor.constraint(lessThanOrEqualTo: self.sellerInfoView.trailingAnchor),
+            self.productInfoView.topAnchor.constraint(equalTo: self.statusButton.bottomAnchor, constant: 16),
             self.productInfoView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
     }

--- a/iOS/SecondHand/SecondHand/Detail/UI/DetailContentView.swift
+++ b/iOS/SecondHand/SecondHand/Detail/UI/DetailContentView.swift
@@ -8,16 +8,15 @@
 import UIKit
 
 class DetailContentView: UIView {
-    var productImageView = UIImageView()
-    var pageControl = UIPageControl()
-    var sellerInfoView = SellerInfoView()
-    var statusButton = UIButton()
-    var productInfoView = ProductInfoView()
-    var communicationInfoView = CommunicationInfoView()
+    private var productImageViewer = ProductImageViewer()
+    private var sellerInfoView = SellerInfoView()
+    private var statusButton = UIButton()
+    private var productInfoView = ProductInfoView()
+    private var communicationInfoView = CommunicationInfoView()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        self.setUI()
+        self.updateStatusButton()
         self.addSubviews()
         self.addConstraints()
     }
@@ -27,21 +26,15 @@ class DetailContentView: UIView {
     }
 
     func update(by data: DetailModel) {
-        guard let productImageURLString = ImageCacheManager.shared.object(forKey: NSString(string: "98/0"))?.path else {
-            print("키 못찾음")
-            return
-        }
-        
         DispatchQueue.main.async {
-            self.productImageView.image = UIImage(contentsOfFile: productImageURLString)
+            self.productImageViewer.update(by: data.imageKeys)
             self.sellerInfoView.update(by: data.sellerName)
             self.productInfoView.update(by: data.productInfo)
             self.communicationInfoView.update(by: data.userInteractionCount)
         }
     }
     
-    private func setUI() {
-        self.productImageView.tintColor = .orange
+    private func updateStatusButton() {
         self.statusButton = self.makeStatusButton()
     }
     
@@ -111,8 +104,7 @@ class DetailContentView: UIView {
     
     private func addSubviews() {
         let subViews = [
-            self.productImageView,
-            self.pageControl,
+            self.productImageViewer,
             self.sellerInfoView,
             self.statusButton,
             self.productInfoView,
@@ -129,44 +121,38 @@ class DetailContentView: UIView {
 // MARK: - Constraint 설정
 extension DetailContentView {
     private func addConstraints() {
-        self.addConstraintsToProductImageView()
-        self.addConstraintsToPageControl()
+        self.addConstraintsToProductImageViewer()
         self.addConstraintsToSellerInfoView()
         self.addConstraintsToStatusButton()
         self.addConstraintsToProductInfoView()
         self.addConstraintsToCommunicationInfoView()
     }
     
-    private func addConstraintsToProductImageView() {
-        let heightRatio: CGFloat = 5 / 4
+    private func addConstraintsToProductImageViewer() {
         NSLayoutConstraint.activate([
-            self.productImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            self.productImageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            self.productImageView.topAnchor.constraint(equalTo: self.topAnchor),
-            self.productImageView.heightAnchor.constraint(
-                equalTo: productImageView.widthAnchor,
-                multiplier: heightRatio
-            )
+            self.productImageViewer.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.productImageViewer.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            self.productImageViewer.topAnchor.constraint(equalTo: self.topAnchor)
         ])
     }
-    
-    private func addConstraintsToPageControl() {
-        NSLayoutConstraint.activate([
-            self.pageControl.leadingAnchor.constraint(equalTo: self.productImageView.leadingAnchor),
-            self.pageControl.trailingAnchor.constraint(equalTo: self.productImageView.trailingAnchor),
-            self.pageControl.bottomAnchor.constraint(equalTo: self.productImageView.bottomAnchor),
-            self.pageControl.heightAnchor.constraint(equalToConstant: 20)
-        ])
-    }
+//
+//    private func addConstraintsToPageControl() {
+//        NSLayoutConstraint.activate([
+//            self.pageControl.leadingAnchor.constraint(equalTo: self.productImageView.leadingAnchor),
+//            self.pageControl.trailingAnchor.constraint(equalTo: self.productImageView.trailingAnchor),
+//            self.pageControl.bottomAnchor.constraint(equalTo: self.productImageView.bottomAnchor),
+//            self.pageControl.heightAnchor.constraint(equalToConstant: 20)
+//        ])
+//    }
     
     private func addConstraintsToSellerInfoView() {
         NSLayoutConstraint.activate([
             self.sellerInfoView.leadingAnchor.constraint(
-                equalTo: self.productImageView.leadingAnchor,
+                equalTo: self.productImageViewer.leadingAnchor,
                 constant: 16
             ),
-            self.sellerInfoView.trailingAnchor.constraint(equalTo: self.productImageView.trailingAnchor, constant: -16),
-            self.sellerInfoView.topAnchor.constraint(equalTo: self.pageControl.bottomAnchor, constant: 16),
+            self.sellerInfoView.trailingAnchor.constraint(equalTo: self.productImageViewer.trailingAnchor, constant: -16),
+            self.sellerInfoView.topAnchor.constraint(equalTo: self.productImageViewer.bottomAnchor, constant: 16),
             self.sellerInfoView.heightAnchor.constraint(equalToConstant: 60)
         ])
     }

--- a/iOS/SecondHand/SecondHand/Detail/UI/DetailContentView.swift
+++ b/iOS/SecondHand/SecondHand/Detail/UI/DetailContentView.swift
@@ -36,6 +36,7 @@ class DetailContentView: UIView {
             self.productImageView.image = UIImage(contentsOfFile: productImageURLString)
             self.sellerInfoView.update(by: data.sellerName)
             self.productInfoView.update(by: data.productInfo)
+            self.communicationInfoView.update(by: data.userInteractionCount)
         }
     }
     
@@ -47,11 +48,23 @@ class DetailContentView: UIView {
     // swiftlint:disable:next function_body_length
     private func makeStatusButton() -> UIButton {
         let button = UIButton(type: .system)
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.contentVerticalAlignment = .center
+        button.contentHorizontalAlignment = .leading
+        button.semanticContentAttribute = .forceRightToLeft
         
         button.setTitle("판매중", for: .normal)
-        button.setImage(UIImage(systemName: "chevron.down"), for: .normal)
+        let chevronImage = UIImage(systemName: "chevron.down")?.withAlignmentRectInsets(
+            UIEdgeInsets(
+                top: -5,
+                left: -2,
+                bottom: -5,
+                right: -2
+            )
+        )
+        button.setImage(chevronImage, for: .normal)
         button.titleLabel?.font = .typo.caption1
-        button.semanticContentAttribute = .forceRightToLeft
         button.tintColor = .black
         button.layer.borderColor = UIColor.gray.cgColor
         button.layer.borderWidth = 0.2
@@ -102,7 +115,8 @@ class DetailContentView: UIView {
             self.pageControl,
             self.sellerInfoView,
             self.statusButton,
-            self.productInfoView
+            self.productInfoView,
+            self.communicationInfoView
         ]
         
         subViews.forEach {
@@ -117,9 +131,10 @@ extension DetailContentView {
     private func addConstraints() {
         self.addConstraintsToProductImageView()
         self.addConstraintsToPageControl()
-        self.addConstraintsToSellerInfo()
+        self.addConstraintsToSellerInfoView()
         self.addConstraintsToStatusButton()
-        self.addConstraintsToProductInfo()
+        self.addConstraintsToProductInfoView()
+        self.addConstraintsToCommunicationInfoView()
     }
     
     private func addConstraintsToProductImageView() {
@@ -139,15 +154,18 @@ extension DetailContentView {
         NSLayoutConstraint.activate([
             self.pageControl.leadingAnchor.constraint(equalTo: self.productImageView.leadingAnchor),
             self.pageControl.trailingAnchor.constraint(equalTo: self.productImageView.trailingAnchor),
-            self.pageControl.bottomAnchor.constraint(equalTo: productImageView.bottomAnchor),
+            self.pageControl.bottomAnchor.constraint(equalTo: self.productImageView.bottomAnchor),
             self.pageControl.heightAnchor.constraint(equalToConstant: 20)
         ])
     }
     
-    private func addConstraintsToSellerInfo() {
+    private func addConstraintsToSellerInfoView() {
         NSLayoutConstraint.activate([
-            self.sellerInfoView.leadingAnchor.constraint(equalTo: productImageView.leadingAnchor, constant: 16),
-            self.sellerInfoView.trailingAnchor.constraint(equalTo: productImageView.trailingAnchor, constant: -16),
+            self.sellerInfoView.leadingAnchor.constraint(
+                equalTo: self.productImageView.leadingAnchor,
+                constant: 16
+            ),
+            self.sellerInfoView.trailingAnchor.constraint(equalTo: self.productImageView.trailingAnchor, constant: -16),
             self.sellerInfoView.topAnchor.constraint(equalTo: self.pageControl.bottomAnchor, constant: 16),
             self.sellerInfoView.heightAnchor.constraint(equalToConstant: 60)
         ])
@@ -155,17 +173,29 @@ extension DetailContentView {
     
     private func addConstraintsToStatusButton() {
         NSLayoutConstraint.activate([
-            self.statusButton.leadingAnchor.constraint(equalTo: sellerInfoView.leadingAnchor),
-            self.statusButton.topAnchor.constraint(equalTo: sellerInfoView.bottomAnchor, constant: 16)
+            self.statusButton.leadingAnchor.constraint(equalTo: self.sellerInfoView.leadingAnchor),
+            self.statusButton.trailingAnchor.constraint(lessThanOrEqualTo: self.sellerInfoView.trailingAnchor),
+            self.statusButton.topAnchor.constraint(equalTo: self.sellerInfoView.bottomAnchor, constant: 16)
         ])
     }
     
-    private func addConstraintsToProductInfo() {
+    private func addConstraintsToProductInfoView() {
         NSLayoutConstraint.activate([
             self.productInfoView.leadingAnchor.constraint(equalTo: self.sellerInfoView.leadingAnchor),
-            self.productInfoView.trailingAnchor.constraint(lessThanOrEqualTo: self.sellerInfoView.trailingAnchor),
-            self.productInfoView.topAnchor.constraint(equalTo: self.statusButton.bottomAnchor, constant: 16),
-            self.productInfoView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+            self.productInfoView.trailingAnchor.constraint(equalTo: self.sellerInfoView.trailingAnchor),
+            self.productInfoView.topAnchor.constraint(equalTo: self.statusButton.bottomAnchor, constant: 16)
+        ])
+    }
+    
+    private func addConstraintsToCommunicationInfoView() {
+        NSLayoutConstraint.activate([
+            self.communicationInfoView.leadingAnchor.constraint(equalTo: self.productInfoView.leadingAnchor),
+            self.communicationInfoView.trailingAnchor.constraint(equalTo: self.sellerInfoView.trailingAnchor),
+            self.communicationInfoView.topAnchor.constraint(
+                equalTo: self.productInfoView.bottomAnchor,
+                constant: 16
+            ),
+            self.communicationInfoView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
     }
 }

--- a/iOS/SecondHand/SecondHand/Detail/UI/DetailToolbar.swift
+++ b/iOS/SecondHand/SecondHand/Detail/UI/DetailToolbar.swift
@@ -32,7 +32,7 @@ class DetailToolbar: UIToolbar {
     }
     
     func configure(price: Int) {
-        self.priceLabel.title = "\(price)"
+        self.priceLabel.title = "\(price)원"
     }
     
     private func makeFavoriteButton() -> UIBarButtonItem {

--- a/iOS/SecondHand/SecondHand/Detail/UI/DetailToolbar.swift
+++ b/iOS/SecondHand/SecondHand/Detail/UI/DetailToolbar.swift
@@ -31,8 +31,8 @@ class DetailToolbar: UIToolbar {
         addItems()
     }
     
-    func configure(price: Int) {
-        self.priceLabel.title = "\(price)원"
+    func update(price: Int) {
+        self.priceLabel.title = FormatPriceGenerator.generate(from: price)
     }
     
     private func makeFavoriteButton() -> UIBarButtonItem {

--- a/iOS/SecondHand/SecondHand/Detail/UI/ProductImageViewer.swift
+++ b/iOS/SecondHand/SecondHand/Detail/UI/ProductImageViewer.swift
@@ -1,0 +1,106 @@
+//
+//  ProductImageViewer.swift
+//  SecondHand
+//
+//  Created by Wood on 2023/07/23.
+//
+
+import UIKit
+
+class ProductImageViewer: UIView {
+    private var imageView = UIImageView()
+    private var pageControl = UIPageControl()
+    private var productImages: [UIImage] = []
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setActionToPageControl()
+        self.pageControl.currentPageIndicatorTintColor = .green
+        self.addSubviews()
+        self.addConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func setActionToPageControl() {
+        self.pageControl.addAction(
+            UIAction(handler: { _ in
+                let imageIndex = self.pageControl.currentPage
+                self.imageView.image = self.productImages[imageIndex]
+            }),
+            for: .valueChanged
+        )
+    }
+    
+    private func loadImagesFrom(keys: [NSString?]) -> [UIImage] {
+        var images: [UIImage] = []
+        keys.forEach { (imageKey: NSString?) in
+            guard let key = imageKey else {
+                print("키값이 캐시에 존재하지 않습니다.")
+                return
+            }
+            
+            guard let productImageURLString = ImageCacheManager.shared.object(forKey: key)?.path else {
+                print("이미지에 해당하는 키를 찾지 못했습니다.")
+                return
+            }
+
+            guard let image = UIImage(contentsOfFile: productImageURLString) else {
+                print("키에 해당하는 이미지를 불러오지 못했습니다.")
+                return
+            }
+            images.append(image)
+        }
+        
+        return images
+    }
+    
+    func update(by imageKeys: [NSString?]) {
+        self.productImages = self.loadImagesFrom(keys: imageKeys)
+        print(productImages)
+        self.pageControl.numberOfPages = self.productImages.count
+        self.pageControl.currentPage = 0
+        self.imageView.image = self.productImages[0]
+    }
+    
+    private func addSubviews() {
+        let subViews = [
+            self.imageView,
+            self.pageControl
+        ]
+        
+        subViews.forEach { (subView: UIView) in
+            subView.translatesAutoresizingMaskIntoConstraints = false
+            self.addSubview(subView)
+        }
+    }
+    
+    private func addConstraints() {
+        self.addConstraintsToImageView()
+        self.addConstraintsToPageControl()
+    }
+    
+    private func addConstraintsToImageView() {
+        let heightRatio: CGFloat = 5 / 4
+        NSLayoutConstraint.activate([
+            self.imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            self.imageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            self.imageView.topAnchor.constraint(equalTo: self.topAnchor),
+            self.imageView.heightAnchor.constraint(
+                equalTo: self.imageView.widthAnchor,
+                multiplier: heightRatio
+            )
+        ])
+    }
+    
+    private func addConstraintsToPageControl() {
+        NSLayoutConstraint.activate([
+            self.pageControl.leadingAnchor.constraint(equalTo: self.imageView.leadingAnchor),
+            self.pageControl.trailingAnchor.constraint(equalTo: self.imageView.trailingAnchor),
+            self.pageControl.topAnchor.constraint(equalTo: self.imageView.bottomAnchor),
+            self.pageControl.heightAnchor.constraint(equalToConstant: 30)
+        ])
+    }
+}

--- a/iOS/SecondHand/SecondHand/Detail/UI/ProductInfoView.swift
+++ b/iOS/SecondHand/SecondHand/Detail/UI/ProductInfoView.swift
@@ -32,7 +32,7 @@ class ProductInfoView: UIView {
     
     func update(by productInfo: DetailModel.ProductInfo) {
         self.nameLabel.text = "\(productInfo.title)"
-        let annotation = productInfo.category + " ・ " + PassedTimeGenerator.calculate(from: productInfo.postedTime)
+        let annotation = productInfo.category + " ・ " + PassedTimeGenerator.generate(from: productInfo.postedTime)
         self.annotationLabel.text = annotation
         self.descriptionLabel.text = "\(productInfo.description)"
     }

--- a/iOS/SecondHand/SecondHand/Detail/UI/ProductInfoView.swift
+++ b/iOS/SecondHand/SecondHand/Detail/UI/ProductInfoView.swift
@@ -50,7 +50,7 @@ extension ProductInfoView {
         let subViews = [
             nameLabel,
             annotationLabel,
-            descriptionLabel,
+            descriptionLabel
         ]
         
         subViews.forEach {
@@ -86,7 +86,8 @@ extension ProductInfoView {
         NSLayoutConstraint.activate([
             descriptionLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             descriptionLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            descriptionLabel.topAnchor.constraint(equalTo: annotationLabel.bottomAnchor, constant: 16)
+            descriptionLabel.topAnchor.constraint(equalTo: annotationLabel.bottomAnchor, constant: 16),
+            descriptionLabel.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         ])
     }
 }

--- a/iOS/SecondHand/SecondHand/Detail/UI/ProductInfoView.swift
+++ b/iOS/SecondHand/SecondHand/Detail/UI/ProductInfoView.swift
@@ -32,7 +32,8 @@ class ProductInfoView: UIView {
     
     func update(by productInfo: DetailModel.ProductInfo) {
         self.nameLabel.text = "\(productInfo.title)"
-        self.annotationLabel.text = "\(productInfo.category) ・ \(productInfo.postedTime)"
+        let annotation = productInfo.category + " ・ " + PassedTimeGenerator.calculate(from: productInfo.postedTime)
+        self.annotationLabel.text = annotation
         self.descriptionLabel.text = "\(productInfo.description)"
     }
     

--- a/iOS/SecondHand/SecondHand/FormatPriceGenerator.swift
+++ b/iOS/SecondHand/SecondHand/FormatPriceGenerator.swift
@@ -1,0 +1,26 @@
+//
+//  FormatPriceGenerator.swift
+//  SecondHand
+//
+//  Created by Wood on 2023/07/22.
+//
+
+import Foundation
+
+struct FormatPriceGenerator {
+    static let numberFormatter: NumberFormatter = {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        return numberFormatter
+    }()
+    
+    private init() {}
+    
+    static func generate(from price: Int) -> String {
+        guard let result = self.numberFormatter.string(from: NSNumber(value: price)) else {
+            return "\(price)원"
+        }
+
+        return "\(result)원"
+    }
+}

--- a/iOS/SecondHand/SecondHand/PassedTimeGenerator.swift
+++ b/iOS/SecondHand/SecondHand/PassedTimeGenerator.swift
@@ -1,0 +1,81 @@
+//
+//  PassedTimeGenerator.swift
+//  SecondHand
+//
+//  Created by Wood on 2023/07/22.
+//
+
+import Foundation
+
+struct PassedTimeGenerator {
+    static private let formatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        let koreanInterval = 32400
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: koreanInterval)
+        let dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        dateFormatter.dateFormat = dateFormat
+        return dateFormatter
+    }()
+    
+    private init() {}
+    
+    static func calculate(from: String) -> String {
+        print(from)
+        guard let formattedInputTime = formatter.date(from: from) else {
+            return ""
+        }
+        
+        let now = Date()
+        var interval = Int(formattedInputTime.distance(to: now))
+        guard (interval / 60) > 0 else {
+            return "\(interval)초 전"
+        }
+        
+        interval /= 60
+        guard (interval / 60) > 0 else {
+            return "\(interval)분 전"
+        }
+        
+        interval /= 60
+        guard (interval / 24) > 0 else {
+            return "\(interval)시간 전"
+        }
+        
+        interval /= 24
+        guard (interval / 30) > 0 else {
+            return "\(interval)일 전"
+        }
+        
+        interval /= 30
+        guard (interval / 12) > 0 else {
+            return "\(interval)달 전"
+        }
+        
+        interval /= 12
+        return "\(interval)년 전"
+    }
+}
+
+// calculate 메소드 코드라인 줄이는데 사용할 예정.
+//enum TimeScale {
+//    case second
+//    case minute
+//    case hour
+//    case day
+//    case month
+//
+//    var boundary: Int {
+//        switch self {
+//        case .second:
+//            return 60
+//        case .minute:
+//            return 60
+//        case .hour:
+//            return 24
+//        case .day:
+//            return 30
+//        case .month:
+//            return 12
+//        }
+//    }
+//}

--- a/iOS/SecondHand/SecondHand/PassedTimeGenerator.swift
+++ b/iOS/SecondHand/SecondHand/PassedTimeGenerator.swift
@@ -20,7 +20,6 @@ struct PassedTimeGenerator {
     private init() {}
     
     static func generate(from: String) -> String {
-        print(from)
         guard let formattedInputTime = formatter.date(from: from) else {
             return ""
         }

--- a/iOS/SecondHand/SecondHand/PassedTimeGenerator.swift
+++ b/iOS/SecondHand/SecondHand/PassedTimeGenerator.swift
@@ -19,7 +19,7 @@ struct PassedTimeGenerator {
     
     private init() {}
     
-    static func calculate(from: String) -> String {
+    static func generate(from: String) -> String {
         print(from)
         guard let formattedInputTime = formatter.date(from: from) else {
             return ""


### PR DESCRIPTION
## 🔨 작업 내용

- 이미지를 다운로드 하여 캐시에 저장
- 한번 열람한 상품의 이미지를 불러올 때 캐시에 접근하여 빠르게 로드
- Clean Architecture에 따라 UseCase를 UIKit 라이브러리로 부터 분리

### 하위 작업

- [x] 이미지 다운로드 후 디스크 캐시에 저장
- [x] 메모리 캐시에 불러올 이미지 경로를 저장


[노션 페이지 링크](https://mixolydian-macadamia-d9b.notion.site/a6d5f7fb424b4555961d857c9c295e67?pvs=4)